### PR TITLE
Multiple query fix upon orphaned articles lists

### DIFF
--- a/query/itwiki/Voci/Voci_orfane_con_interlink.sql
+++ b/query/itwiki/Voci/Voci_orfane_con_interlink.sql
@@ -12,6 +12,13 @@ AND pl_from NOT IN
 FROM page
 WHERE page_namespace <> 0)
 AND pl_from NOT IN
+(SELECT page_id
+FROM page JOIN redirect ON page_id=rd_from
+  WHERE page_namespace=0 AND rd_namespace = 0
+    AND NOT EXISTS ( SELECT * 
+      FROM page AS p JOIN pagelinks ON p.page_id = pl_from 
+        WHERE p.page_namespace IN (0, 4, 10, 12, 100, 102) AND pl_namespace = 0 AND pl_title = page.page_title))
+AND pl_from NOT IN
 (SELECT cl_from
 FROM categorylinks, pagelinks
 WHERE cl_to = pl_title

--- a/query/itwiki/Voci/Voci_orfane_in_ordine_alfabetico.sql
+++ b/query/itwiki/Voci/Voci_orfane_in_ordine_alfabetico.sql
@@ -12,6 +12,13 @@ AND pl_from NOT IN
 FROM page
 WHERE page_namespace <> 0)
 AND pl_from NOT IN
+(SELECT page_id
+FROM page JOIN redirect ON page_id=rd_from
+  WHERE page_namespace=0 AND rd_namespace = 0
+    AND NOT EXISTS ( SELECT * 
+      FROM page AS p JOIN pagelinks ON p.page_id = pl_from 
+        WHERE p.page_namespace IN (0, 4, 10, 12, 100, 102) AND pl_namespace = 0 AND pl_title = page.page_title))
+AND pl_from NOT IN
 (SELECT cl_from
 FROM categorylinks, pagelinks
 WHERE cl_to = pl_title

--- a/query/itwiki/Voci/Voci_orfane_per_creatore.sql
+++ b/query/itwiki/Voci/Voci_orfane_per_creatore.sql
@@ -14,6 +14,13 @@ AND pl_from NOT IN
 FROM page
 WHERE page_namespace <> 0)
 AND pl_from NOT IN
+(SELECT page_id
+FROM page JOIN redirect ON page_id=rd_from
+  WHERE page_namespace=0 AND rd_namespace = 0
+    AND NOT EXISTS ( SELECT * 
+      FROM page AS p JOIN pagelinks ON p.page_id = pl_from 
+        WHERE p.page_namespace IN (0, 4, 10, 12, 100, 102) AND pl_namespace = 0 AND pl_title = page.page_title))
+AND pl_from NOT IN
 (SELECT cl_from
 FROM categorylinks, pagelinks
 WHERE cl_to = pl_title

--- a/query/itwiki/Voci/Voci_orfane_per_data_di_creazione.sql
+++ b/query/itwiki/Voci/Voci_orfane_per_data_di_creazione.sql
@@ -14,6 +14,13 @@ AND pl_from NOT IN
 FROM page
 WHERE page_namespace <> 0)
 AND pl_from NOT IN
+(SELECT page_id
+FROM page JOIN redirect ON page_id=rd_from
+  WHERE page_namespace=0 AND rd_namespace = 0
+    AND NOT EXISTS ( SELECT * 
+      FROM page AS p JOIN pagelinks ON p.page_id = pl_from 
+        WHERE p.page_namespace IN (0, 4, 10, 12, 100, 102) AND pl_namespace = 0 AND pl_title = page.page_title))
+AND pl_from NOT IN
 (SELECT cl_from
 FROM categorylinks, pagelinks
 WHERE cl_to = pl_title

--- a/query/itwiki/Voci/Voci_orfane_per_dimensione.sql
+++ b/query/itwiki/Voci/Voci_orfane_per_dimensione.sql
@@ -12,6 +12,13 @@ AND pl_from NOT IN
 FROM page
 WHERE page_namespace <> 0)
 AND pl_from NOT IN
+(SELECT page_id
+FROM page JOIN redirect ON page_id=rd_from
+  WHERE page_namespace=0 AND rd_namespace = 0
+    AND NOT EXISTS ( SELECT * 
+      FROM page AS p JOIN pagelinks ON p.page_id = pl_from 
+        WHERE p.page_namespace IN (0, 4, 10, 12, 100, 102) AND pl_namespace = 0 AND pl_title = page.page_title))
+AND pl_from NOT IN
 (SELECT cl_from
 FROM categorylinks, pagelinks
 WHERE cl_to = pl_title

--- a/query/itwiki/Voci/Voci_orfane_senza_interlink.sql
+++ b/query/itwiki/Voci/Voci_orfane_senza_interlink.sql
@@ -12,6 +12,13 @@ AND pl_from NOT IN
 FROM page
 WHERE page_namespace <> 0)
 AND pl_from NOT IN
+(SELECT page_id
+FROM page JOIN redirect ON page_id=rd_from
+  WHERE page_namespace=0 AND rd_namespace = 0
+    AND NOT EXISTS ( SELECT * 
+      FROM page AS p JOIN pagelinks ON p.page_id = pl_from 
+        WHERE p.page_namespace IN (0, 4, 10, 12, 100, 102) AND pl_namespace = 0 AND pl_title = page.page_title))
+AND pl_from NOT IN
 (SELECT cl_from
 FROM categorylinks, pagelinks
 WHERE cl_to = pl_title


### PR DESCRIPTION
I suggest these edits because the current versions of the queries doesn't exclude orphaned redirects from the valid links, so they ignore several real orphaned articles. Please read carefully my proposed changes before convalidating them. Thanks in advance.